### PR TITLE
make CrashLog() support windows

### DIFF
--- a/crash_unix.go
+++ b/crash_unix.go
@@ -1,0 +1,18 @@
+// +build freebsd openbsd netbsd dragonfly darwin linux
+
+package log
+
+import (
+	"log"
+	"os"
+	"syscall"
+)
+
+func CrashLog(file string) {
+	f, err := os.OpenFile(file, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0666)
+	if err != nil {
+		log.Println(err.Error())
+	} else {
+		syscall.Dup2(int(f.Fd()), 2)
+	}
+}

--- a/crash_win.go
+++ b/crash_win.go
@@ -1,0 +1,37 @@
+// +build windows
+
+package log
+
+import (
+	"log"
+	"os"
+	"syscall"
+)
+
+var (
+	kernel32         = syscall.MustLoadDLL("kernel32.dll")
+	procSetStdHandle = kernel32.MustFindProc("SetStdHandle")
+)
+
+func setStdHandle(stdhandle int32, handle syscall.Handle) error {
+	r0, _, e1 := syscall.Syscall(procSetStdHandle.Addr(), 2, uintptr(stdhandle), uintptr(handle), 0)
+	if r0 == 0 {
+		if e1 != 0 {
+			return error(e1)
+		}
+		return syscall.EINVAL
+	}
+	return nil
+}
+
+func CrashLog(file string) {
+	f, err := os.OpenFile(file, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0666)
+	if err != nil {
+		log.Println(err.Error())
+	} else {
+		err = setStdHandle(syscall.STD_ERROR_HANDLE, syscall.Handle(f.Fd()))
+		if err != nil {
+			log.Println(err.Error())
+		}
+	}
+}

--- a/log.go
+++ b/log.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -54,15 +53,6 @@ func init() {
 
 func Logger() *log.Logger {
 	return _log._log
-}
-
-func CrashLog(file string) {
-	f, err := os.OpenFile(file, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0666)
-	if err != nil {
-		log.Println(err.Error())
-	} else {
-		syscall.Dup2(int(f.Fd()), 2)
-	}
 }
 
 func SetLevel(level LogLevel) {
@@ -210,14 +200,14 @@ func (l *logger) rotate() error {
 }
 
 func (l *logger) doRotate(suffix string) error {
+	// Notice: Not check error, is this ok?
+	l.fd.Close()
+
 	lastFileName := l.fileName + "." + l.logSuffix
 	err := os.Rename(l.fileName, lastFileName)
 	if err != nil {
 		return err
 	}
-
-	// Notice: Not check error, is this ok?
-	l.fd.Close()
 
 	err = l.SetOutputByName(l.fileName)
 	if err != nil {


### PR DESCRIPTION
I find that CrashLog() puts panic goroutines dump into a file.

Now it supports Windows now. Tested in windows7 x64.
