### PR TITLE
Update log.go

### DIFF
--- a/log.go
+++ b/log.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"runtime"
 	"sync"
 	"time"
 )
@@ -49,6 +50,7 @@ var _log *logger = New()
 
 func init() {
 	SetFlags(Ldate | Ltime | Lshortfile)
+	SetHighlighting(runtime.GOOS != "windows")
 }
 
 func Logger() *log.Logger {


### PR DESCRIPTION
If the system is when microsoft windows, turn off logging highlighted. Because TiDB output messy log in windows, so I strongly recommend highlighting the windows closed.