### PR TITLE
fix undefined syscall.Dup2 on linux/arm64.

### DIFF
--- a/crash_unix.go
+++ b/crash_unix.go
@@ -13,6 +13,6 @@ func CrashLog(file string) {
 	if err != nil {
 		log.Println(err.Error())
 	} else {
-		syscall.Dup2(int(f.Fd()), 2)
+		syscall.Dup3(int(f.Fd()), 2, 0)
 	}
 }


### PR DESCRIPTION
syscall.Dup2 is not supported on linux/arm64, use syscall.Dup3 instead.
Fix #4 